### PR TITLE
secure DISPLAY using xauth

### DIFF
--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -38,6 +38,10 @@ SALT="$(create_passwd 16)"
 password="$(create_passwd 16)"
 PASSWORD_SHA1="$(echo -n "${password}${SALT}" | openssl dgst -sha1 | awk '{print $NF}')"
 
+# setup secure DISPLAY
+export DISPLAY=:$(shuf -n 1 -i 100-200)
+xauth add ${DISPLAY} . $(xxd -l 16 -p /dev/urandom)
+export XAUTHORITY="${HOME}/.Xauthority"
 
 # The `$CONFIG_FILE` environment variable is exported as it is used in the main
 # `script.sh.erb` file when launching the Jupyter Notebook server.

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -37,5 +37,5 @@ apptainer exec ${CONTAINER} xpra start \
     --exit-with-windows=yes \
     --daemon=no \
     --clipboard=yes \
-    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset" \
+    --xvfb="/usr/bin/Xvfb +extension Composite -screen 0 1920x1080x24+32 -nolisten tcp -noreset -auth ${XAUTHORITY}" \
     $DISPLAY


### PR DESCRIPTION
This ensures other users on the same node who know the DISPLAY value can't open windows or otherwise access the display.
Generate a random DISPLAY and then register it with xauth to add a magic cookie in ~/.Xauthority
(this is analogous to what is done by ssh -X). Then ensure we use auth to secure the xvfb.
